### PR TITLE
VCPCM-2113 [Docs]: Remove EOL Windows OS from VisualCron Requirements

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -7,30 +7,30 @@ hide_title: 'true'
 
 ### Operating systems
 
-- VisualCron is designed for Windows based computers
-- VisualCron works on the following operating systems: Windows Server 2008 R2/2012/2016/2019/2022 and Windows 8/10/11
-- VisualCron works on both 32-bit and 64-bit processors
-- VisualCron requires .NET 4.8
+- VisualCron is designed for Windows-based computers.
+- VisualCron works on the following operating systems: Microsoft-supported Windows Server versions (2016/2019/2022) and Windows 10/11.
+- VisualCron works on both 32-bit and 64-bit processors.
+- VisualCron requires .NET 4.8.
 
 ### Computer requirements (Server only)
 
-- Operating system - recommended Windows operating system is Windows Server 2008 R2/2012/2016/2019/2019/2022
-- Disk space - please reserve 1GB to 4GB depending on how much logging you need to store
-- CPU - 2GHz or more, quad core or more
-- Memory - 4GB or more
+- Operating system – recommended Windows Server versions: 2016/2019/2022.
+- Disk space – please reserve 1GB to 4GB depending on how much logging you need to store.
+- CPU – 2GHz or more, quad core or more.
+- Memory – 4GB or more.
 
 ### Computer requirements (Client only)
 
-- Operating system - recommended Windows operating system is Windows 8/10/11
-- Disk space - please reserve 1GB
-- CPU - 2GHz or more, quad core or more
-- Memory - 4GB or more
-- Minimum screen resolution 1920*1080
-- Computer requirements (Client and Server)
+- Operating system – recommended Windows versions: Windows 10/11.
+- Disk space – please reserve 1GB.
+- CPU – 2GHz or more, quad core or more.
+- Memory – 4GB or more.
+- Minimum screen resolution: 1920×1080.
 
-### Operating system - recommended Windows operating system is Windows Server 2008 R2/2012/2016/2019/2022
+### Computer requirements (Client and Server)
 
-- Disk space - please reserve 1GB to 4GB depending on how much logging you need to store
-- CPU - 2GHz or more, quad core or more
-- Memory - 4GB or more
-- Minimum screen resolution 1920*1080
+- Operating system – recommended Windows Server versions: 2016/2019/2022.
+- Disk space – please reserve 1GB to 4GB depending on how much logging you need to store.
+- CPU – 2GHz or more, quad core or more.
+- Memory – 4GB or more.
+- Minimum screen resolution: 1920×1080.


### PR DESCRIPTION
Summary of Changes:
- Removed Windows Server 2008 R2 and Windows Server 2012 from the supported OS list.
- Updated references to "Microsoft-supported Windows Server versions (2016/2019/2022)" and Windows 10/11.
- No changes made to hardware specs .
- This change is aligned with incremental documentation update approach.