### PR TITLE
VCPCM-1983: Mentioned deprecation for SMTP Basic Auth for Office365 connections

### DIFF
--- a/docs/client-user-interface/server/connection-smtp.md
+++ b/docs/client-user-interface/server/connection-smtp.md
@@ -55,7 +55,7 @@ Encryption
 * Cryptographic protocol: TLS
 * Security Mode: Implicit
  
-**Office 365**
+**Office 365 (Deprecated after April 2026 by [Microsoft](https://techcommunity.microsoft.com/blog/exchange/exchange-online-to-retire-basic-auth-for-client-submission-smtp-auth/4114750))**
 
 Main settings
 * Address: smtp.office365.com


### PR DESCRIPTION
Mentioned deprecation for SMTP Basic Auth for Office365 connections according to https://techcommunity.microsoft.com/blog/exchange/exchange-online-to-retire-basic-auth-for-client-submission-smtp-auth/4114750

Local help updated too.