### PR TITLE
VCPCM-3138: Document 13.2.1 permission changes for Task Manager and Remote File Explorer

### DIFF
--- a/docs/client-user-interface/server/main-user-permissions.md
+++ b/docs/client-user-interface/server/main-user-permissions.md
@@ -131,3 +131,22 @@ See the list of all permissions with a description in the [Supported permissions
 **Overriding group permissions**
 
 From VisualCron version 6.1.2. permissions can be overridden on Job level so you can set specific permission for a group on a specific Job. From version 8.4.2 you can override Credential permissions.
+
+**Default groups**
+
+VisualCron includes two built-in groups: **Administrators** and **Viewers**.
+
+**Administrators** have full access to all objects and features.
+
+**Viewers** are intended for read-oriented monitoring access. The following table describes the default Viewers group permissions as of VisualCron 13.2.1:
+
+| Feature | Read | Add | Edit | Delete | Execute |
+|---------|:----:|:---:|:----:|:------:|:-------:|
+| Jobs | ✓ | | | | |
+| Tasks | ✓ | | | | |
+| Log | ✓ | | | | |
+| Audit Log | ✓ | | | | |
+| Task Manager | ✓ | | | | |
+| Remote File Explorer | ✓ | | | | |
+| Connections | ✓ | | | | |
+

--- a/docs/security.md
+++ b/docs/security.md
@@ -7,6 +7,20 @@ hide_title: 'true'
 
 Many actions have been taken to ensure security. Look at the following chapters to learn more.
 
+### Task Manager — Delete Removed from Viewers Default (13.2.1)
+
+Prior to VisualCron 13.2.1, the default Viewers group included **Task Manager → Delete**, which allowed Viewer-role users to terminate system processes on the connected server. This permission has been removed from the Viewers group default in 13.2.1.
+
+Existing customized groups that explicitly granted Task Manager → Delete are not automatically changed. Only installations that have not modified the Viewers group baseline are affected. Administrators who require process termination for a non-administrator role must grant Task Manager → Delete explicitly.
+
+### Remote File Explorer — Effective Permissions in Remote Connections (13.2.1)
+
+When **Remote File Explorer → Read** is enabled for a user connecting remotely (non-local connection), the effective capability includes file upload, modification, and execution running as NT AUTHORITY\SYSTEM on the server host — broader than the "Read" label implies.
+
+As of VisualCron 13.2.1, when Read is enabled on a remote connection the interface surfaces the full set of effective permissions so administrators are not misled by the read-only label.
+
+Administrators should audit any existing group configurations that include Remote File Explorer → Read for remote users. If read-only monitoring is the intended use case, granting this permission to non-administrator groups on remote connections is not recommended.
+
 ### TLS Communication Between Client and Server
 
 We are using the [NetTcpBinding](https://learn.microsoft.com/en-us/dotnet/api/system.servicemodel.nettcpbinding?view=dotnet-plat-ext-8.0) class uses TCP for message transport. Security for the transport mode is provided by implementing Transport Layer Security (TLS) over TCP. The TLS implementation is provided by the operating system.

--- a/docs/security.md
+++ b/docs/security.md
@@ -7,19 +7,17 @@ hide_title: 'true'
 
 Many actions have been taken to ensure security. Look at the following chapters to learn more.
 
-### Task Manager — Delete Removed from Viewers Default (13.2.1)
+### Task Manager Permissions for the Viewers Group (13.2.1)
 
-Prior to VisualCron 13.2.1, the default Viewers group included **Task Manager → Delete**, which allowed Viewer-role users to terminate system processes on the connected server. This permission has been removed from the Viewers group default in 13.2.1.
+As of VisualCron 13.2.1, the default Viewers group does not include **Task Manager → Delete**. The Viewers role is intended for read-oriented monitoring access.
 
-Existing customized groups that explicitly granted Task Manager → Delete are not automatically changed. Only installations that have not modified the Viewers group baseline are affected. Administrators who require process termination for a non-administrator role must grant Task Manager → Delete explicitly.
+Administrators who need to grant delete permissions to a non-administrator role can do so by explicitly adding Task Manager → Delete to a custom group. Existing customized groups are not affected by this default.
 
-### Remote File Explorer — Effective Permissions in Remote Connections (13.2.1)
+### Remote File Explorer — Permissions in Remote Connections (13.2.1)
 
-When **Remote File Explorer → Read** is enabled for a user connecting remotely (non-local connection), the effective capability includes file upload, modification, and execution running as NT AUTHORITY\SYSTEM on the server host — broader than the "Read" label implies.
+As of VisualCron 13.2.1, when **Remote File Explorer → Read** is enabled for a remote (non-local) connection, the interface displays the full set of effective permissions for that context. This ensures administrators have a clear view of what access is being granted before saving the configuration.
 
-As of VisualCron 13.2.1, when Read is enabled on a remote connection the interface surfaces the full set of effective permissions so administrators are not misled by the read-only label.
-
-Administrators should audit any existing group configurations that include Remote File Explorer → Read for remote users. If read-only monitoring is the intended use case, granting this permission to non-administrator groups on remote connections is not recommended.
+For least-privilege setups, it is encouraged to review Remote File Explorer permission assignments for any group that is not intended to have write access to the server file system.
 
 ### TLS Communication Between Client and Server
 


### PR DESCRIPTION
### Summary

- Adds a Default groups section to the User Permissions page documenting the built-in Administrators and Viewers groups, including a table of default Viewers permissions as of 13.2.1
- Adds two security advisories to the top of the Security page covering breaking/notable permission changes in 13.2.1:
- Task Manager → Delete has been removed from the default Viewers group; existing customized groups are unaffected
- Remote File Explorer → Read on remote connections grants broader effective permissions than the label implies (file upload, edit, execute as NT AUTHORITY\SYSTEM); the UI now surfaces this as of 13.2.1

### Pages changed

- docs/client-user-interface/server/main-user-permissions.md
- docs/security.md