### PR TITLE
Wire EULA into CHM build via terms-and-conditions mapping

### DIFF
--- a/chm-config.json
+++ b/chm-config.json
@@ -24,10 +24,10 @@
       "mdFile": "docs/visualcron-documentation.md",
       "label": "VisualCron Documentation"
     },
-    "license": {
+    "terms-and-conditions": {
       "chmFile": "license.htm",
-      "mdFile": "docs/license.md",
-      "label": "license"
+      "mdFile": "docs/_eula.mdx",
+      "label": "Terms and Conditions"
     },
     "requirements": {
       "chmFile": "system_requirements.htm",


### PR DESCRIPTION
## Summary
- The `license` entry in `chm-config.json` was orphaned after the May 16 T&C cutover — `'license'` is no longer in `sidebars.js`, so the build script never looked it up.
- `terms-and-conditions` is in the sidebar but had no mapping; the build's `.md` fallback couldn't find the `.mdx` source and silently skipped the page.
- Repoint the entry to `docs/_eula.mdx` (plain Markdown, no JSX/imports — `marked` handles it cleanly) and keep `chmFile: "license.htm"` so existing context-help anchors continue to resolve.
- Verified locally: `node scripts/build-chm.js` processes 685 docs, 0 skipped, and `chm-output/license.htm` (~23KB) contains the full EULA with a "Terms and Conditions" title.

## Tradeoff
The notice banner from `terms-and-conditions.mdx` (the wrapper with `import Eula from './_eula.mdx'`) is not in the CHM output, since the builder cannot evaluate MDX imports. Confirmed acceptable.