### PR TITLE
docs(VCPCM-3481): document column name references in For Each loop variables

### DIFF
--- a/docs/client-user-interface/server/job-tasks-loop-functionality.md
+++ b/docs/client-user-interface/server/job-tasks-loop-functionality.md
@@ -85,7 +85,35 @@ Depending on type comparison you enter different kind of values/Variables.
 Enter a Variable that contains a list. You may need to alter field separator, text qualifier or line break depending on the format of the Variable list.
 
 ![](../../../static/img/Client%20User%20Interface/Main%20Menu/Server/Jobs/Job%20Tasks/Task%20Main%20Settings/Loop%20Settings/Loop%20For%20each%20x%20in%20y.png)
- 
+
+**Referencing columns in For Each loops**
+
+When a For Each loop iterates over multi-column data (such as a CSV file), each row is available as an array. You can reference individual columns from the current row in two ways:
+
+*By numeric index:*
+
+```
+{LOOP(CurrentValueXArray|0)}    — first column
+{LOOP(CurrentValueXArray|8)}    — ninth column
+```
+
+*By column name:*
+
+```
+{LOOP(CurrentValueXArray|Email)}
+{LOOP(CurrentValueXArray|CustomerID)}
+```
+
+Column name references require that the data has a header row. VisualCron reads the first row as the column name map. Name matching is case-insensitive.
+
+Using column names makes workflows resilient to column reordering — if a CSV gains a new column or the order changes, name-based references continue to resolve correctly. Numeric index references will silently return the wrong value if the column order shifts.
+
+| Index syntax (fragile) | Name syntax (resilient) |
+|---|---|
+| `{LOOP(CurrentValueXArray\|0)}` | `{LOOP(CurrentValueXArray\|CustomerID)}` |
+| `{LOOP(CurrentValueXArray\|3)}` | `{LOOP(CurrentValueXArray\|Email)}` |
+| `{LOOP(CurrentValueXArray\|7)}` | `{LOOP(CurrentValueXArray\|Department)}` |
+
 **Sleep/Wait in each iteration**
 
 Sets the wait time between each iteration. This is especially interesting if you are using a While loop because you might want to save resources and not check _all_ the time.
@@ -146,11 +174,11 @@ Task Id for the selected end Task in the loop.
  
 **Column position that it used in For Each loop**
 
-The numeric value of column position where x value is picked up.
- 
+The column position where the x value is picked up in a For Each loop. This can be a numeric index (e.g. `0` for the first column) or a column header name (e.g. `Email`). See [Referencing columns in For Each loops](#referencing-columns-in-for-each-loops) for details and examples.
+
 **Field separator**
 
-The character that is used to separate feilds in For Each loop.
+The character that is used to separate fields in For Each loop.
  
 **Text qualifier**
 


### PR DESCRIPTION
## Summary

- Adds a new **"Referencing columns in For Each loops"** section to `job-tasks-loop-functionality.md` documenting both the existing numeric-index syntax and the new column-name-based syntax (e.g. `{LOOP(CurrentValueXArray|Email)}`)
- Updates the **Column Position** loop variable description to cover both reference styles and links to the new section
- Fixes a pre-existing typo: `feilds` ? `fields` in the Field Separator entry

## Related

Jira: [VCPCM-3481](https://smatechnologies.atlassian.net/browse/VCPCM-3481) - Support Column Name References in Loop/Array Variables (merged to master)

## Test plan

- [ ] Verify the new "Referencing columns in For Each loops" section renders correctly in Docusaurus
- [ ] Confirm the comparison table displays properly (escaped pipes in table cells)
- [ ] Check the anchor link in the Column Position description resolves to the new section

?? Generated with [Claude Code](https://claude.com/claude-code)

[VCPCM-3481]: https://smatechnologies.atlassian.net/browse/VCPCM-3481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ