### PR TITLE
Add third-party integration support note to Requirements page

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -43,3 +43,9 @@ hide_title: 'true'
 | CPU                      | 2 GHz or more, quad core or better                                              |
 | Memory                   | 12 GB or more                                                                    |
 | Screen resolution        | Minimum 1920×1080                                                               |
+
+:::note
+
+VisualCron supports third-party integrations but can only assist with versions that are actively maintained by their vendors. Requests involving end-of-life tools may be closed without resolution.
+
+:::


### PR DESCRIPTION
Clarifies that VisualCron can only assist with vendor-maintained versions of third-party integrations; end-of-life tool requests may be closed without resolution.