### PR TITLE
Update settings-log-settings.md retention Q&A (resolves #612 conflict)

### DIFF
--- a/docs/client-user-interface/server/settings-log-settings.md
+++ b/docs/client-user-interface/server/settings-log-settings.md
@@ -169,7 +169,10 @@ Q: Is all 4GB available for use?
 * No, not all of the 4GB is available for storage - this is because the SQLCE compact capability is separate from VisualCron. We recommend taking a look at what SQLCE Compact is: [SQL Server Compact](https://en.wikipedia.org/wiki/SQL_Server_Compact).
 
 Q: How does the internal database handle file growth? Is there a mechanism (e.g., auto-shrink, compression, pre-allocation) that might explain why the file size appears unchanged even though new data is being added? 
-* The routine runs every 6 hours as part of server (this cannot be changed/adapted because of this). What this routine does is that it cleans according to row count and time period set in database settings. For example, if the file size exceeds 3.2 GB, 80% of the data is kept, including the number of days. Otherwise, both are kept. If the file size is still too high, SQLCE compact is run to optimize. 
+* The routine runs every 12 hours as part of server (this cannot be changed/adapted because of this). What this routine does is that it cleans according to row count and time period set in database settings. For example, if the file size exceeds 3.2 GB, 80% of the data is kept, including the number of days. Otherwise, both are kept. If the file size is still too high, SQLCE compact is run to optimize. 
 
 Q: How we can monitor or confirm that new data is actually being stored correctly within the internal .sdf?  
 * The easiest way is to check the logs within the client. If the new data exists, it is written to the database.
+
+Q: We've had the product for several years and never had issues with logging. The settings have not changed but our environment is only retaining X amount of days instead of X. Is this normal? 
+*  This is normal since the environment has grown over time (more jobs have been added, more connections, etc.) If the settings has not been changed but the environment has, this is why the product is only retaining X amount of days of retention. The settings will need to be configured based off how many days worth of retention is needed or how many rows of data.


### PR DESCRIPTION
Re-applies kbono01's #612 on top of #596, which had landed first and caused a merge conflict on `settings-log-settings.md`.

Changes (identical to #612, credit to @kbono01):
- Cleanup routine cadence: every 6 hours -> every 12 hours
- New Q&A on retention shrinking as the environment grows

Closes #612.