### PR TITLE
Fix Docusaurus build errors blocking the site build

### DIFF
--- a/docs/client-user-interface/main-menu.md
+++ b/docs/client-user-interface/main-menu.md
@@ -7,8 +7,8 @@ hide_title: 'true'
 
 The main menu is the ribbon at the top of the VisualCron client window. It is organized into the following tabs:
 
-* [File](file/file) - import/export, updates, settings, manage servers and translation.
-* [Server](server/server) - server status, settings, user permissions, health, SLA and ROI.
+* [File](file/file.md) - import/export, updates, settings, manage servers and translation.
+* [Server](server/server.md) - server status, settings, user permissions, health, SLA and ROI.
 * [Tools](tools/overview) - explore, objects, calendar, flow chart and gantt chart.
 * [Reports](reports) - reports for Jobs, Tasks, logs, notifications, connections and the server.
 * [Interface](interface/overview) - column, filter and theme options for the grid.

--- a/docs/client-user-interface/server/job-tasks/string-tasks/json-decode.md
+++ b/docs/client-user-interface/server/job-tasks/string-tasks/json-decode.md
@@ -7,7 +7,7 @@ hide_title: 'true'
 
 The String - JSON Decode Task allows you to decode a JSON string from a file or value/Variable into formatted output.
 
-![](../../../../../static/img/Client%20User%20Interface/Main%20Menu/Server/Jobs/Job%20Tasks/Tasks/String%20Tasks/JSON%Decode.png)
+![](../../../../../static/img/Client%20User%20Interface/Main%20Menu/Server/Jobs/Job%20Tasks/Tasks/String%20Tasks/JSON%20Decode.png)
 
 **JSON Decode** tab
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -23,7 +23,7 @@ For least-privilege setups, it is encouraged to review Remote File Explorer perm
 
 Please be aware that when upgrading to v12+, the client and server version must match. This version is not backwards compatible with any pre v12 versions. 
 
-![](../../static/img/Get%20VisualCron/Download%20Install%20Upgrade%20and%20Uninstall/12.0.0%20Reminder.png)
+![](../static/img/Get%20VisualCron/Download%20Install%20Upgrade%20and%20Uninstall/12.0.0%20Reminder.png)
 
 ### TLS Communication Between Client and Server
 


### PR DESCRIPTION
Three build-blocking issues prevented the Docusaurus production build from completing. All three are fixed and a clean `npm run build` now succeeds (`[SUCCESS] Generated static files`).

## Fixes

| File | Problem | Fix |
|------|---------|-----|
| `docs/client-user-interface/server/job-tasks/string-tasks/json-decode.md` | `URIError: URI malformed` during MDX compile | Malformed percent-escape `JSON%Decode.png` -> `JSON%20Decode.png` (matches real file `JSON Decode.png`) |
| `docs/security.md` | Image `12.0.0 Reminder.png` could not be resolved | Over-deep relative path `../../static/...` -> `../static/...` (file sits at `docs/` root; rest of the file already used `../static`) |
| `docs/client-user-interface/main-menu.md` | Broken links (`onBrokenLinks: throw`) for File/Server tabs | Reference source files: `file/file` -> `file/file.md`, `server/server` -> `server/server.md` |

The `main-menu.md` broken links were pre-existing on `main` but masked: the build died at the MDX compile stage before the link checker ran. Once the two MDX errors were fixed, the link checker ran and threw, so this was fixed too to get a green build.