### PR TITLE
Slack OAuth scopes and private channel support

### DIFF
--- a/docs/client-user-interface/server/connection-slack.md
+++ b/docs/client-user-interface/server/connection-slack.md
@@ -106,12 +106,29 @@ The Redirect URL configured in the Slack app must use HTTPS (for example `https:
 
 ![](../../../static/img/slack_visualcronpermissions.png)
 
+### Required OAuth scopes
+
+The Slack app used for this connection must be authorized with the following scopes:
+
+* commands
+* chat:write
+* channels:read
+* files:write
+* users:read
+* groups:read
+
+| Scope | Required for |
+|---|---|
+| `files:write` | Uploading files (e.g. Take Screenshot &rarr; Slack, attachments) |
+| `users:read` | "Send to User" resolution by username/email |
+| `groups:read` | Resolving private channels by name |
+
+:::note
+Existing Slack connections created before this update were authenticated with a reduced scope set. If tasks fail with `missing_scope`, re-run **Authenticate** on the connection to request the additional scopes (`files:write`, `users:read`, `groups:read`).
+:::
+
 ### Troubleshooting
  
 *"Missing scope" error*
 
-Make sure the following oauth scopes are setup:
-
-* chat:write
-* chat:write.public
-* incoming-webhook
+Make sure the [Required OAuth scopes](#required-oauth-scopes) above are set up, then re-run **Authenticate** on the connection.

--- a/docs/client-user-interface/server/job-tasks/messaging-tasks/slack-send-message.md
+++ b/docs/client-user-interface/server/job-tasks/messaging-tasks/slack-send-message.md
@@ -9,3 +9,7 @@ The Task - Slack - Send message Task is able to send messages
 
 ![](../../../../../static/img/Client%20User%20Interface/Main%20Menu/Server/Jobs/Job%20Tasks/Tasks/Messaging%20Tasks/slack%20-%20send%20message.png)
 
+**Channel**
+
+The channel to send the message to. Supports both public and private channels by name (e.g. `#general` or `#private-channel`). Resolving a private channel by name requires the `groups:read` scope; see [Required OAuth scopes](../../connection-slack#required-oauth-scopes). Connections authenticated before this scope was added must re-authenticate to pick it up.
+


### PR DESCRIPTION
## Summary
- Add `files:write`, `users:read`, `groups:read` to the required Slack OAuth scopes on the connection page, with a table explaining what each scope enables and a re-authenticate note for connections created before this update (VCPCM-3736).
- Document the Channel field on the Send Message task, covering private channel support by name and its `groups:read` dependency (VCPCM-3740).

## Test plan
- [x] `yarn build` passes (pre-existing broken-anchor warning on `job-tasks-loop-functionality` is unrelated to this change)