### PR TITLE
Remove Mobile App page

### DIFF
--- a/chm-config.json
+++ b/chm-config.json
@@ -289,11 +289,6 @@
       "mdFile": "docs/using-visualcron/enable-windows-authentication.md",
       "label": "Enable Windows Authentication / Active Directory Logon"
     },
-    "using-visualcron/mobile-app": {
-      "chmFile": "mobile-app.htm",
-      "mdFile": "docs/using-visualcron/mobile-app.md",
-      "label": "Mobile App"
-    },
     "using-visualcron/visualcron-api": {
       "chmFile": "visualcron_api.htm",
       "mdFile": "docs/using-visualcron/visualcron-api.md",

--- a/docs/using-visualcron/mobile-app.md
+++ b/docs/using-visualcron/mobile-app.md
@@ -1,8 +1,0 @@
----
-sidebar_label: 'Mobile App'
-hide_title: 'true'
----
-
-## Mobile App
-
-Mobile app exists for Android and iOS.

--- a/sidebars.js
+++ b/sidebars.js
@@ -110,7 +110,6 @@ module.exports = {
             'using-visualcron/visualcron-web-client',
             'using-visualcron/installation-of-web-client',
             'using-visualcron/enable-windows-authentication',
-            'using-visualcron/mobile-app',
             'using-visualcron/visualcron-api',
             'using-visualcron/dot-net-csharp-vbnet',
             'using-visualcron/powershell',


### PR DESCRIPTION
## What

Removes the **Mobile App** page (`using-visualcron/mobile-app`), which stated a VisualCron mobile app exists for Android and iOS. There is no VisualCron mobile app, so the page was misleading/confusing to users.

## Changes

- Deleted `docs/using-visualcron/mobile-app.md`
- Removed the sidebar entry from `sidebars.js`
- Removed the mapping block from `chm-config.json`

No other page links to this topic, so there is no broken-link risk.

## Verification

`yarn build` passes locally. The build reports one pre-existing broken anchor on an unrelated page (`job-tasks-loop-functionality`), which is not introduced by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)