### PR TITLE
VCPCM-3473: numeric conversion variable functions ({INTEGER,LONG,DECIMAL,DOUBLE})

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,13 @@ hide_title: 'true'
 ## Change Log
 
 
+### Unreleased
+
+#### Features
+
+:star: Client/Server: Numeric Conversion Variable Functions for INTEGER, LONG, DECIMAL and DOUBLE (VCPCM-3473)
+
+
 ### 13.2.2 [2026-05-16]
 
 #### Notes

--- a/docs/client-user-interface/server/global-variables.md
+++ b/docs/client-user-interface/server/global-variables.md
@@ -65,6 +65,10 @@ Examples:
 ```{DECIMAL(5.5|0.00|0)}``` returns 5.50
 
 ```{DOUBLE(abc|-1)}``` returns -1, the default value, because the value is not a number
+
+```{INTEGER(2147483648|-1)}``` returns -1, the default value, because 2147483648 is outside the 32-bit integer range (use ```{LONG}``` for larger whole numbers)
+
+```{LONG(2147483648|0)}``` returns 2147483648, which is within the 64-bit integer range
  
 **System variables**
 

--- a/docs/client-user-interface/server/global-variables.md
+++ b/docs/client-user-interface/server/global-variables.md
@@ -44,6 +44,28 @@ Conditional functions. A *{LOGIC(If|...)}* variable compares two values and retu
 
 Math functions such as Add, Subtract, Multiply, Divide, Abs, Round, Ceiling, Floor and Pow, with an optional output format.
  
+**Number conversion**
+
+Convert a value to a specific numeric type inside a variable expression. There are four families: *{INTEGER}* (32-bit integer), *{LONG}* (64-bit integer), *{DECIMAL}* and *{DOUBLE}*. Each family accepts two forms:
+
+```{INTEGER(value|defaultValue)}```
+
+```{INTEGER(value|format|defaultValue)}```
+
+The first argument is the value to convert. The last argument is the default value, which is returned when the value cannot be converted (empty, non numeric, out of range, or when an invalid format is supplied). The optional middle argument is a standard .NET numeric format string that is applied to the converted result. *{INTEGER}* and *{LONG}* truncate any fractional part toward zero, while *{DECIMAL}* and *{DOUBLE}* keep it. Values are parsed using the invariant culture, so a period is always the decimal separator.
+
+Examples:
+
+```{INTEGER(5.9|0)}``` returns 5
+
+```{INTEGER(5.9|000|0)}``` returns 005
+
+```{LONG(9999999999|0)}``` returns 9999999999
+
+```{DECIMAL(5.5|0.00|0)}``` returns 5.50
+
+```{DOUBLE(abc|-1)}``` returns -1, the default value, because the value is not a number
+ 
 **System variables**
 
 These are values collected from the current computer/server, such as Environment and Memory variables and system uptime.

--- a/docs/client-user-interface/server/global-variables.md
+++ b/docs/client-user-interface/server/global-variables.md
@@ -52,7 +52,15 @@ Convert a value to a specific numeric type inside a variable expression. There a
 
 ```{INTEGER(value|format|defaultValue)}```
 
-The first argument is the value to convert. The last argument is the default value, which is returned when the value cannot be converted (empty, non numeric, out of range, or when an invalid format is supplied). The optional middle argument is a standard .NET numeric format string that is applied to the converted result. *{INTEGER}* and *{LONG}* truncate any fractional part toward zero, while *{DECIMAL}* and *{DOUBLE}* keep it. Values are parsed using the invariant culture, so a period is always the decimal separator.
+The first argument is the value to convert. The last argument is the default value. The optional middle argument is a standard or custom .NET numeric format string that is applied to the converted result. *{INTEGER}* and *{LONG}* truncate any fractional part toward zero, while *{DECIMAL}* and *{DOUBLE}* keep it.
+
+Values are parsed using the invariant culture, so a period is always the decimal separator and thousand separators are not accepted in the value. Leading zeros are removed, scientific notation such as 1e3 is accepted, and any space before or after the value is ignored.
+
+The default value is returned, exactly as you typed it, when the value is not a number, when it is only spaces, when it is outside the range of the target type, when *{DOUBLE}* would result in an infinite or non numeric value, and when the format cannot be applied. In the three argument form the default value is returned without the format applied.
+
+A format is rejected when it is longer than 64 characters, and a standard format is rejected when its precision is above 99, so a format such as F100000000 returns the default value instead of building a very large string.
+
+An empty value has to reach the function through another variable, for example ```{INTEGER({STRING(Null)}|0)}```, which returns 0. Writing an empty first argument directly, as in ```{INTEGER(|0)}```, is read as a single argument and reports an invalid number of arguments instead of returning the default value.
 
 Examples:
 
@@ -69,6 +77,12 @@ Examples:
 ```{INTEGER(2147483648|-1)}``` returns -1, the default value, because 2147483648 is outside the 32-bit integer range (use ```{LONG}``` for larger whole numbers)
 
 ```{LONG(2147483648|0)}``` returns 2147483648, which is within the 64-bit integer range
+
+```{DECIMAL(1e3|0)}``` returns 1000, because scientific notation is accepted
+
+```{INTEGER(abc|000|-1)}``` returns -1, the default value, without the 000 format applied to it
+
+```{DOUBLE(1e400|-1)}``` returns -1, the default value, because the value is too large to be a valid number
  
 **System variables**
 


### PR DESCRIPTION
  Documents the numeric conversion variable functions added under VCPCM-3473 in the
  "Number conversion" section of the Global variables page, plus an Unreleased changelog entry.

  ## Covered

  - The four families — `{INTEGER}` (Int32), `{LONG}` (Int64), `{DECIMAL}`, `{DOUBLE}` — and both
    signatures: `{FAMILY(value|defaultValue)}` and `{FAMILY(value|format|defaultValue)}`.
  - Truncation toward zero for the integer families vs. fractional preservation for
    `{DECIMAL}`/`{DOUBLE}`; invariant-culture parsing.
  - When the default value is returned: non-numeric, whitespace-only, out of range, non-finite
    `{DOUBLE}` results, and unusable formats — returned verbatim and unformatted.
  - Input grammar: leading zeros, scientific notation, no thousand separators, surrounding
    whitespace ignored.
  - The 64-character / precision-99 format size caps added as SEC1 hardening.
  - The literal `{INTEGER(|0)}` tokenizer caveat: read as one argument, reports an invalid
    argument count rather than returning the default.

  Every example is backed by a row in `VariableParsingTests.cs` in the product repo. Reviewed
  against the VCPCM-3473 spec, which was corrected in the same pass (the format size cap was
  implemented but had never been written down).