### PR TITLE
fix(docs): make For Each column-reference section a real heading

### DIFF
--- a/docs/client-user-interface/server/job-tasks-loop-functionality.md
+++ b/docs/client-user-interface/server/job-tasks-loop-functionality.md
@@ -86,7 +86,7 @@ Enter a Variable that contains a list. You may need to alter *Use column*, *Fiel
 
 ![](../../../static/img/Client%20User%20Interface/Main%20Menu/Server/Jobs/Job%20Tasks/Task%20Main%20Settings/Loop%20Settings/Loop%20For%20each%20x%20in%20y.png)
 
-**Referencing columns in For Each loops**
+#### Referencing columns in For Each loops
 
 When a For Each loop iterates over multi-column data (such as a CSV file), each row is available as an array. You can reference individual columns from the current row in two ways:
 


### PR DESCRIPTION
## Problem

The Docusaurus build reports a broken anchor:

```
- Broken anchor on source page path = /client-user-interface/server/job-tasks-loop-functionality:
   -> linking to #referencing-columns-in-for-each-loops
```

## Cause

#565 added both the cross-reference link and its target section, but the target was written as bold text:

```
**Referencing columns in For Each loops**
```

Bold text renders as `<p><strong>...</strong></p>` and produces no `id`, so there was nothing on the page for the link to resolve to.

## Change

Promoted that line to an `h4`, which generates the `referencing-columns-in-for-each-loops` slug the link already points at. One-line diff, no prose changes.

## Verification

`npm run build` exits 0 with no broken-anchor warning, and the generated `build/client-user-interface/server/job-tasks-loop-functionality/index.html` now contains the slug twice: once as the heading `id`, once as the link `href`.

## Note

This is now the only `h4` in a stretch of bold pseudo-headings under "Working with loops", so it picks up a right-rail TOC entry and a hover anchor icon. That seems right for a section with code blocks and a table, but say the word if you would rather drop the cross-reference sentence and keep the page uniform.